### PR TITLE
add css to sideEffects 

### DIFF
--- a/packages/react-notion-x/package.json
+++ b/packages/react-notion-x/package.json
@@ -8,7 +8,7 @@
   "main": "build/cjs/index.js",
   "module": "build/esm/index.js",
   "typings": "build/esm/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": [ "*.css" ],
   "engines": {
     "node": ">=12"
   },


### PR DESCRIPTION
Working on a react app and everything works as expected in dev mode but in production mode tree shaking ignores the css in the react-notion-s library

I have added
```
import 'react-notion-x/src/styles.css'
import 'prismjs/themes/prism-tomorrow.css'
```

but I had to change sideEffects to include css files to get the library to work in production mode.

Was it a decision to set "sideEffects" to false? Because I think setting it to not exclude css will help me and others looking to include this into their projects. 

Thanks! 

And this is an awesome library btw. I've been enjoying working with it and having the convenience to use Notion as my CMS.